### PR TITLE
fix(berror): 重命名 WarpErr 为 WrapErr 并添加 nil 检查

### DIFF
--- a/berror/error.go
+++ b/berror/error.go
@@ -41,14 +41,23 @@ func GetErrMessage(err error) string {
 	return trueErr.Message
 }
 
-// WarpErr wraps an error with additional error information.
+// WrapErr wraps an error with additional error information.
 // It preserves the code and message from the original error while attaching the error info.
-func WarpErr(err *BErr, errInfo error) *BErr {
+// Returns Unknown error if err is nil to prevent panic.
+func WrapErr(err *BErr, errInfo error) *BErr {
+	if err == nil {
+		err = Unknown
+	}
 	return &BErr{
 		Code:      err.Code,
 		Message:   err.Message,
 		ErrorInfo: errInfo,
 	}
+}
+
+// Deprecated: WarpErr is a misspelled alias for WrapErr. Use WrapErr instead.
+func WarpErr(err *BErr, errInfo error) *BErr {
+	return WrapErr(err, errInfo)
 }
 
 // DecodeErr decodes an error into its code and message components.


### PR DESCRIPTION
## 修复问题

解决 Issue #37: WarpErr 函数名拼写错误 + 缺少 nil 检查

## 问题描述

1. **拼写错误**：函数名 `WarpErr` 应为 `WrapErr`
   - "Wrap" 是标准的 Go 术语（参考 errors.Wrap）
   - "Warp" 是拼写错误

2. **缺少 nil 检查**：当传入 `nil` 作为第一个参数时会导致 panic
   ```go
   // 会 panic: nil pointer dereference
   WarpErr(nil, someError)
   ```

## 修复方案

1. **创建新函数 WrapErr**
   - 正确的函数名称
   - 添加 nil 检查，若 err 为 nil 则使用 Unknown 错误
   - 所有新代码应使用此函数

2. **保留 WarpErr 作为向后兼容的别名**
   - 标记为 Deprecated（已弃用）
   - 内部调用 WrapErr
   - 允许现有代码继续运行
   - 提供迁移路径

## 代码变化

```go
// 新的正确函数
func WrapErr(err *BErr, errInfo error) *BErr {
    if err == nil {
        err = Unknown  // 防止 panic
    }
    return &BErr{...}
}

// 向后兼容别名
func WarpErr(err *BErr, errInfo error) *BErr {
    return WrapErr(err, errInfo)  // 调用新函数
}
```

## 影响范围

- **安全性提升**：防止了潜在的 nil pointer panic
- **API 改进**：函数名现在符合 Go 命名约定
- **向后兼容**：现有代码不会破裂（但建议迁移）

## 测试

建议添加以下测试用例：
- `TestWrapErr_WithNilError`: 验证 nil 参数不会 panic
- `TestWrapErr_WithError`: 验证正常情况

Closes #37
