### PR TITLE
fix(gin): 修复 BaseEndpoint SetMiddleware 接收器类型

### DIFF
--- a/gin/endpoint.go
+++ b/gin/endpoint.go
@@ -26,6 +26,6 @@ func (b *BaseEndpoint) SetMiddleware(middlewares []gin.HandlerFunc) {
 	b.MiddlewareFunc = middlewares
 }
 
-func (b BaseEndpoint) Middleware() []gin.HandlerFunc {
+func (b *BaseEndpoint) Middleware() []gin.HandlerFunc {
 	return b.MiddlewareFunc
 }


### PR DESCRIPTION
## 修复问题

解决 Issue #44: BaseEndpoint SetMiddleware 接收器类型不一致

## 问题描述

`BaseEndpoint` 结构体的两个方法接收器类型不一致：

```go
// SetMiddleware 使用指针接收器
func (b *BaseEndpoint) SetMiddleware(middlewares []gin.HandlerFunc) {
    b.MiddlewareFunc = middlewares
}

// 但 Middleware 使用值接收器！
func (b BaseEndpoint) Middleware() []gin.HandlerFunc {
    return b.MiddlewareFunc
}
```

这会导致：
- 接口实现的不一致性
- 可能的类型断言失败
- 代码可读性和可维护性问题

## 修复方案

将 `Middleware()` 方法改为使用指针接收器，与 `SetMiddleware()` 保持一致：

```go
func (b *BaseEndpoint) Middleware() []gin.HandlerFunc {
    return b.MiddlewareFunc
}
```

## 影响范围

- **代码质量**：改进方法一致性
- **接口实现**：确保所有实现者都一致
- **可维护性**：减少潜在的混淆

## 测试

- 验证 `Middleware()` 方法仍能正常工作
- 确保所有实现 `Ep` 接口的类型继续工作

Closes #44
