### PR TITLE
fix(rabbitmq): 修复信号处理竞态条件

### DIFF
--- a/rabbitmq/consumer.go
+++ b/rabbitmq/consumer.go
@@ -204,9 +204,9 @@ RUNLOOP:
 
 func (c *consumer) gracefulShutdown() {
 	// 阻塞，直到接收到shutdown的信号
-	ch := make(chan os.Signal)
+	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGINT, syscall.SIGKILL)
-	_ = <-ch
+	<-ch
 	//关闭后，Run方法中处理消息的协程将会关闭，不再处理新消息。
 	c.close = true
 	c.wait.Wait()


### PR DESCRIPTION
## 修复问题

解决 Issue #36: RabbitMQ 信号处理竞态条件

## 问题描述

`rabbitmq/consumer.go` 的 `gracefulShutdown()` 方法使用无缓冲 signal channel：

```go
func (c *consumer) gracefulShutdown() {
    ch := make(chan os.Signal)  // 无缓冲通道！
    signal.Notify(ch, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGINT, syscall.SIGKILL)
    _ = <-ch
    c.close = true
    c.wait.Wait()
}
```

问题：
- 无缓冲通道在没有接收者时会丢失信号
- 创建 goroutine 时存在竞态条件窗口
- 根据 Go 官方文档，signal 通道应该有缓冲

## 修复方案

使用缓冲通道接收信号：

```go
func (c *consumer) gracefulShutdown() {
    ch := make(chan os.Signal, 1)  // 缓冲大小至少为 1
    signal.Notify(ch, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGINT, syscall.SIGKILL)
    <-ch  // 直接接收，无需忽略
    c.close = true
    c.wait.Wait()
}
```

## 影响范围

- **可靠性提升**：确保信号不会被丢失
- **竞态条件修复**：消除信号处理中的竞态条件
- **标准实践**：遵循 Go signal 包的最佳实践

## 参考

- [os/signal - Go Documentation](https://golang.org/pkg/os/signal/)
- [Common signal handling patterns](https://golang.org/pkg/os/signal/#example_Notify)

Closes #36
