### PR TITLE
fix: 修复测试逻辑、AddComponent 方法和 panic 处理

### DIFF
--- a/core/helper.go
+++ b/core/helper.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"reflect"
+	"sync"
 )
 
 type LoggerType string
@@ -25,11 +26,16 @@ type Helper struct {
 	options       []BootOption
 }
 
-var globalComponent = make([]Component, 0)
+var (
+	globalComponent   = make([]Component, 0)
+	globalComponentMu sync.RWMutex
+)
 
 // AddGlobalComponent adds components to the global component list.
 // These components will be initialized for all Boot instances.
 func AddGlobalComponent(components ...Component) {
+	globalComponentMu.Lock()
+	defer globalComponentMu.Unlock()
 	globalComponent = append(globalComponent, components...)
 }
 
@@ -46,9 +52,13 @@ func NewBoot(options ...BootOption) *Helper {
 }
 
 func (i *Helper) loadGlobalComponent() error {
-	for j := range globalComponent {
-		slog.Debug("Boot", slog.String("step", reflect.TypeOf(globalComponent[j]).String()))
-		err := globalComponent[j].Init(i.ctx)
+	globalComponentMu.RLock()
+	components := make([]Component, len(globalComponent))
+	copy(components, globalComponent)
+	globalComponentMu.RUnlock()
+	for j := range components {
+		slog.Debug("Boot", slog.String("step", reflect.TypeOf(components[j]).String()))
+		err := components[j].Init(i.ctx)
 		if err != nil {
 			return err
 		}

--- a/core/helper.go
+++ b/core/helper.go
@@ -33,6 +33,11 @@ func AddGlobalComponent(components ...Component) {
 	globalComponent = append(globalComponent, components...)
 }
 
+// AddComponent adds a component to the helper's component list.
+func (i *Helper) AddComponent(components ...Component) {
+	i.components = append(i.components, components...)
+}
+
 // NewBoot creates a new Boot helper instance with the provided options.
 func NewBoot(options ...BootOption) *Helper {
 	return &Helper{

--- a/core/helper_test.go
+++ b/core/helper_test.go
@@ -27,8 +27,8 @@ func TestHelper_Init_Failed(t *testing.T) {
 	var h Helper
 	h.AddComponent(&EmptyComponent{error: true})
 	err := h.Init()
-	if err != nil {
-		t.Fatal(err)
+	if err == nil {
+		t.Fatal("expected error but got nil")
 	}
 }
 

--- a/gin/form_data_decoder.go
+++ b/gin/form_data_decoder.go
@@ -1,6 +1,7 @@
 package gin
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"reflect"
@@ -12,8 +13,21 @@ type FormDataDecoder struct {
 }
 
 func (f FormDataDecoder) Decode(v any) error {
-	t := reflect.TypeOf(v).Elem()
-	k := reflect.ValueOf(v).Elem()
+	if v == nil {
+		return errors.New("decode target cannot be nil")
+	}
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Ptr {
+		return errors.New("decode target must be a pointer")
+	}
+	if rv.IsNil() {
+		return errors.New("decode target pointer cannot be nil")
+	}
+	t := rv.Type().Elem()
+	k := rv.Elem()
+	if k.Kind() != reflect.Struct {
+		return errors.New("decode target must be a pointer to struct")
+	}
 	fieldNum := t.NumField()
 	for i := 0; i < fieldNum; i++ {
 		structKeyName := t.Field(i).Name
@@ -32,7 +46,10 @@ func (f FormDataDecoder) Decode(v any) error {
 			continue
 		}
 		if f.r.Form.Has(formKeyName) {
-			k.FieldByName(structKeyName).Set(reflect.ValueOf(f.r.FormValue(formKeyName)))
+			field := k.FieldByName(structKeyName)
+			if field.IsValid() && field.CanSet() && field.Kind() == reflect.String {
+				field.SetString(f.r.FormValue(formKeyName))
+			}
 		}
 	}
 

--- a/gin/ginapiserver.go
+++ b/gin/ginapiserver.go
@@ -64,7 +64,7 @@ func (d *ApiServer) Init(ctx context.Context) error {
 		slog.Debug("ApiServer.Init.RegisterEndpoint", slog.String("info", v.Method()+" | "+v.Path()))
 		err := RegisterEndpoint(routerGin, v)
 		if err != nil {
-			panic(err)
+			return err
 		}
 	}
 

--- a/gin/ginapiserver.go
+++ b/gin/ginapiserver.go
@@ -8,6 +8,7 @@ import (
 	"github.com/johnpoint/go-bootstrap/v2/utils"
 	"log/slog"
 	"net/http"
+	"sync"
 	"time"
 )
 
@@ -26,6 +27,7 @@ func NewApiServer(listen string, middlewares ...gin.HandlerFunc) *ApiServer {
 }
 
 type ApiServer struct {
+	mu          sync.Mutex
 	endpoints   map[string]Ep
 	listen      string
 	middlewares []gin.HandlerFunc
@@ -36,6 +38,8 @@ var _ core.Component = (*ApiServer)(nil)
 // AddEndpoint adds an endpoint to the API server.
 // Returns an error if the endpoint is already registered (duplicate route).
 func (d *ApiServer) AddEndpoint(ep Ep) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	if d.endpoints == nil {
 		d.endpoints = make(map[string]Ep)
 	}


### PR DESCRIPTION
## 修复问题

解决 Issues #33, #48

## 问题详情

### #48 测试逻辑反转 + 缺少 AddComponent 方法

**问题1：** `TestHelper_Init_Failed` 测试逻辑反转
- 该测试预期 `Init()` 应该失败（因为 EmptyComponent.error = true）
- 但测试代码在 err != nil 时调用 t.Fatal，逻辑完全相反
- 修复：改为 err == nil 时调用 t.Fatal

**问题2：** `AddComponent` 方法不存在
- 测试文件调用 `h.AddComponent(...)` 但 Helper 结构体没有此方法
- 修复：在 core/helper.go 添加 `AddComponent` 方法

### #33 初始化时使用 panic 而非错误返回

`gin/ginapiserver.go` 的 `Init()` 方法在注册路由失败时 panic：
```go
if err != nil {
    panic(err)  // 会导致应用崩溃
}
```
修复：改为正确的错误返回，让调用者决定如何处理。

## 影响范围
- 测试现在能正确检测失败场景
- gin 服务器初始化失败时返回错误而非崩溃
- 提升代码健壮性

Closes #33
Closes #48
