### PR TITLE
fix(rabbitmq): 用循环替代 goto 并支持可配置重连延迟

### DIFF
--- a/rabbitmq/config.go
+++ b/rabbitmq/config.go
@@ -1,6 +1,8 @@
 package rabbitmq
 
 import (
+	"time"
+
 	"github.com/go-playground/validator/v10"
 )
 
@@ -21,6 +23,7 @@ type Config struct {
 	NoWait          bool                   `yaml:"no-wait"`
 	Args            map[string]interface{} `yaml:"args"`
 	ChannelNum      int                    `yaml:"channel-num"`
+	ReconnectDelay  time.Duration          `yaml:"reconnect-delay"`
 }
 
 func (c *Config) Validate() error {

--- a/rabbitmq/consumer.go
+++ b/rabbitmq/consumer.go
@@ -110,16 +110,24 @@ const (
 	NackRequeue
 )
 
-func (c *consumer) Run(handler func(context.Context, *amqp.Delivery) Action) {
-RECONNECT:
-	err := c.GetConn()
-	if err != nil {
-		time.Sleep(3 * time.Second)
-		goto RECONNECT
+func (c *consumer) reconnectDelay() time.Duration {
+	if c.channel.config.ReconnectDelay > 0 {
+		return c.channel.config.ReconnectDelay
 	}
+	return 3 * time.Second
+}
 
-	for i := range c.channel.Chan {
-		go c.doHandlerLoop(c.ctx, i, handler)
+func (c *consumer) Run(handler func(context.Context, *amqp.Delivery) Action) {
+	for {
+		err := c.GetConn()
+		if err != nil {
+			time.Sleep(c.reconnectDelay())
+			continue
+		}
+		for i := range c.channel.Chan {
+			go c.doHandlerLoop(c.ctx, i, handler)
+		}
+		return
 	}
 }
 
@@ -148,57 +156,64 @@ func (c *consumer) reCreateChannel(index int) error {
 }
 
 func (c *consumer) doHandlerLoop(ctx context.Context, channelIndex int, handler func(context.Context, *amqp.Delivery) Action) {
-RUNLOOP:
-	cc := make(chan *amqp.Error)
-	c.channel.Chan[channelIndex].NotifyClose(cc)
-	delivery, err := c.GetDelivery(channelIndex)
-	if err != nil {
-		slog.Error("consumer.doHandlerLoop", slog.String("info", fmt.Sprintf("can't get delivery: %+v", err)))
-		time.Sleep(3 * time.Second)
-		goto RUNLOOP
-	}
 	for {
-		select {
-		case msg, ok := <-delivery:
-			if !ok {
+		cc := make(chan *amqp.Error)
+		c.channel.Chan[channelIndex].NotifyClose(cc)
+		delivery, err := c.GetDelivery(channelIndex)
+		if err != nil {
+			slog.Error("consumer.doHandlerLoop", slog.String("info", fmt.Sprintf("can't get delivery: %+v", err)))
+			time.Sleep(c.reconnectDelay())
+			continue
+		}
+
+		shouldRestart := false
+	innerLoop:
+		for {
+			select {
+			case msg, ok := <-delivery:
+				if !ok {
+					if !c.close {
+						c.reCreateChannel(channelIndex)
+						shouldRestart = true
+						break innerLoop
+					}
+					return
+				}
 				if !c.close {
-					c.reCreateChannel(channelIndex)
-					goto RUNLOOP
+					c.wait.Add(1)
+					switch handler(ctx, &msg) {
+					case Ack:
+						err := msg.Ack(false)
+						if err != nil {
+							slog.Error("consumer.doHandlerLoop", slog.String("info", "can't ack message: "+err.Error()))
+						}
+					case NackDiscard:
+						err := msg.Nack(false, false)
+						if err != nil {
+							slog.Error("consumer.doHandlerLoop", slog.String("info", "can't nack message: "+err.Error()))
+						}
+					case NackRequeue:
+						err := msg.Nack(false, true)
+						if err != nil {
+							slog.Error("consumer.doHandlerLoop", slog.String("info", "can't nack message: "+err.Error()))
+						}
+					}
+					c.wait.Done()
 				} else {
 					return
 				}
-			}
-			if !c.close {
-				c.wait.Add(1)
-				switch handler(ctx, &msg) {
-				case Ack:
-					err := msg.Ack(false)
-					if err != nil {
-						slog.Error("consumer.doHandlerLoop", slog.String("info", "can't ack message: "+err.Error()))
-					}
-				case NackDiscard:
-					err := msg.Nack(false, false)
-					if err != nil {
-						slog.Error("consumer.doHandlerLoop", slog.String("info", "can't nack message: "+err.Error()))
-					}
-				case NackRequeue:
-					err := msg.Nack(false, true)
-					if err != nil {
-						slog.Error("consumer.doHandlerLoop", slog.String("info", "can't nack message: "+err.Error()))
-					}
-				}
-				c.wait.Done()
-			} else {
-				return
-			}
 
-		case <-cc:
-			if !c.close {
-				c.reCreateChannel(channelIndex)
-				goto RUNLOOP
-			} else {
+			case <-cc:
+				if !c.close {
+					c.reCreateChannel(channelIndex)
+					shouldRestart = true
+					break innerLoop
+				}
 				return
 			}
+		}
+		if !shouldRestart {
+			return
 		}
 	}
 }


### PR DESCRIPTION
## 修复问题

解决 Issues #32, #49

## 问题详情

### #32 用循环替代 goto 语句

`rabbitmq/consumer.go` 中大量使用 `goto` 语句：
- `Run()` 函数用 `goto RECONNECT` 重新连接
- `doHandlerLoop()` 函数用 `goto RUNLOOP` 重新启动消息循环

`goto` 语句的问题：
- 可读性差，代码流程难以理解
- 可能导致变量作用域问题
- Go 社区不推荐使用

修复：将所有 `goto` 替换为 `for` 循环配合 `continue`/`break`。

### #49 移除硬编码延迟

代码中硬编码了重连延迟 `3 * time.Second`，无法根据环境调整。

修复：在 `Config` 结构体添加 `ReconnectDelay` 字段，支持自定义重连延迟，默认值为 3 秒。

## 影响范围
- 代码可读性和可维护性提升
- 支持自定义重连延迟，适应不同环境需求
- 消除潜在的 goto 跳转问题

Closes #32
Closes #49
