### PR TITLE
feat(core): 添加 ComponentCloser 接口支持优雅关闭

### DIFF
--- a/core/component.go
+++ b/core/component.go
@@ -10,6 +10,12 @@ type Component interface {
 	Init(ctx context.Context) error
 }
 
+// ComponentCloser is an optional interface for components that support graceful shutdown.
+// Implement this interface alongside Component to enable graceful shutdown.
+type ComponentCloser interface {
+	Close(ctx context.Context) error
+}
+
 type EmptyComponent struct {
 	error  bool
 	logger *slog.Logger
@@ -23,5 +29,12 @@ func (d *EmptyComponent) Init(ctx context.Context) error {
 	return nil
 }
 
+// Close implements ComponentCloser for EmptyComponent.
+func (d *EmptyComponent) Close(ctx context.Context) error {
+	slog.Debug("EmptyComponent Close")
+	return nil
+}
+
 // 检查接口是否实现
 var _ Component = (*EmptyComponent)(nil)
+var _ ComponentCloser = (*EmptyComponent)(nil)

--- a/core/helper.go
+++ b/core/helper.go
@@ -124,6 +124,19 @@ func (i *Helper) InitWithoutGlobalComponent() error {
 	return nil
 }
 
+// Close gracefully shuts down all components that implement ComponentCloser.
+// Components are closed in reverse initialization order.
+func (i *Helper) Close(ctx context.Context) error {
+	for j := len(i.components) - 1; j >= 0; j-- {
+		if closer, ok := i.components[j].(ComponentCloser); ok {
+			if err := closer.Close(ctx); err != nil {
+				slog.Error("Boot.Close", slog.String("step", "close component"), slog.String("error", err.Error()))
+			}
+		}
+	}
+	return nil
+}
+
 // Init initializes the boot helper with both global and instance components.
 // It first loads all global components, then loads the instance's components.
 func (i *Helper) Init() error {

--- a/core/helper_test.go
+++ b/core/helper_test.go
@@ -28,7 +28,26 @@ func TestHelper_Init_Failed(t *testing.T) {
 	h.AddComponent(&EmptyComponent{error: true})
 	err := h.Init()
 	if err == nil {
-		t.Fatal("expected error but got nil")
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestHelper_Close(t *testing.T) {
+	var h Helper
+	h.AddComponent(&EmptyComponent{})
+	if err := h.Init(); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.Close(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEmptyComponent_Close(t *testing.T) {
+	var c EmptyComponent
+	err := c.Close(context.Background())
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
## 修复问题

解决 Issues #35, #45

## 问题详情

### #45 扩展 Component 接口添加关闭方法

现有 `Component` 接口只有 `Init` 方法，没有生命周期管理的关闭方法，导致：
- 应用关闭时无法通知组件进行清理
- 连接、文件句柄等资源可能无法正确释放

### #35 实现优雅关闭机制

没有标准化的关闭机制，每个组件需要自行处理关闭逻辑。

## 解决方案

引入**可选的** `ComponentCloser` 接口，避免破坏现有接口：

```go
type ComponentCloser interface {
    Close(ctx context.Context) error
}
```

优点：
- **向后兼容**：现有组件无需修改
- **可选实现**：只有需要关闭逻辑的组件才需要实现
- **标准化**：统一关闭方式

`Helper.Close()` 方法会按**逆序**关闭所有实现了 `ComponentCloser` 的组件，确保依赖关系的正确处理。

`EmptyComponent` 同时实现了 `ComponentCloser` 作为示例。

## 影响范围
- 无破坏性变更（新增可选接口）
- 应用可通过 `helper.Close(ctx)` 优雅关闭
- 为 RabbitMQ、gin 等组件的优雅关闭提供基础

Closes #35
Closes #45
