### PR TITLE
fix(gin): 添加 Recovery 中间件并修复日志安全性

### DIFF
--- a/gin/ginapiserver.go
+++ b/gin/ginapiserver.go
@@ -49,6 +49,8 @@ func (d *ApiServer) AddEndpoint(ep Ep) error {
 func (d *ApiServer) Init(ctx context.Context) error {
 	gin.SetMode(gin.ReleaseMode)
 	routerGin := gin.New()
+	// Always add Recovery middleware to catch handler panics and prevent server crash
+	routerGin.Use(gin.Recovery())
 	if len(d.middlewares) != 0 {
 		routerGin.Use(d.middlewares...)
 	}

--- a/gin/middleware/log_plus.go
+++ b/gin/middleware/log_plus.go
@@ -7,8 +7,19 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 )
+
+// sensitiveHeaders lists header names that should be redacted in logs.
+var sensitiveHeaders = []string{
+	"authorization",
+	"cookie",
+	"set-cookie",
+	"x-api-key",
+	"x-auth-token",
+	"x-access-token",
+}
 
 type reqLog struct {
 	Header http.Header `json:"header"`
@@ -19,6 +30,16 @@ type reqLog struct {
 	In     time.Time   `json:"in"`
 	Out    time.Time   `json:"out"`
 	Method string      `json:"method"`
+}
+
+// LogPlusConfig holds configuration options for LogPlusMiddlewareWithConfig.
+type LogPlusConfig struct {
+	// LogBody controls whether request and response bodies are logged.
+	// WARNING: Enabling this may expose sensitive data. Default: false.
+	LogBody bool
+	// LogHeaders controls whether request headers are logged.
+	// Sensitive headers (Authorization, Cookie, etc.) are always redacted.
+	LogHeaders bool
 }
 
 // CustomResponseWriter is a wrapper around gin.ResponseWriter that captures response body data.
@@ -39,28 +60,69 @@ func (w *CustomResponseWriter) WriteString(s string) (int, error) {
 	return w.ResponseWriter.WriteString(s)
 }
 
-// LogPlusMiddleware returns a Gin middleware that logs detailed request and response information.
-// It captures request headers, body, URL, method, and response data with a unique request ID.
+// redactHeaders returns a copy of headers with sensitive values replaced by "[REDACTED]".
+func redactHeaders(headers http.Header) http.Header {
+	redacted := headers.Clone()
+	for key := range redacted {
+		lower := strings.ToLower(key)
+		for _, sensitive := range sensitiveHeaders {
+			if lower == sensitive {
+				redacted.Set(key, "[REDACTED]")
+				break
+			}
+		}
+		if strings.Contains(lower, "token") || strings.Contains(lower, "secret") || strings.Contains(lower, "key") {
+			redacted.Set(key, "[REDACTED]")
+		}
+	}
+	return redacted
+}
+
+// LogPlusMiddleware returns a Gin middleware that logs request method and URL.
+// Request/response bodies are NOT logged to prevent sensitive data exposure.
+// Use LogPlusMiddlewareWithConfig for full control over logging behavior.
 func LogPlusMiddleware() gin.HandlerFunc {
+	return LogPlusMiddlewareWithConfig(LogPlusConfig{
+		LogBody:    false,
+		LogHeaders: true,
+	})
+}
+
+// LogPlusMiddlewareWithConfig returns a Gin middleware with configurable logging behavior.
+// WARNING: Setting LogBody to true may expose sensitive data (passwords, tokens, PII) in logs.
+func LogPlusMiddlewareWithConfig(cfg LogPlusConfig) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var r reqLog
 		r.ReqID = utils.RandomString()
-		r.Header = c.Request.Header
 		r.Method = c.Request.Method
+		r.URL = c.Request.URL.RequestURI()
+		r.In = time.Now()
+
+		if cfg.LogHeaders {
+			r.Header = redactHeaders(c.Request.Header)
+		}
+
 		rawReqData, _ := io.ReadAll(c.Request.Body)
 		c.Request.Body.Close()
 		c.Request.Body = io.NopCloser(bytes.NewBuffer(rawReqData))
+		if cfg.LogBody {
+			r.Body = string(rawReqData)
+		} else {
+			r.Body = "[REDACTED]"
+		}
 
-		r.Body = string(rawReqData)
-		r.URL = c.Request.URL.RequestURI()
 		customWriter := &CustomResponseWriter{body: bytes.NewBufferString(""), ResponseWriter: c.Writer}
 		c.Writer = customWriter
-		// 处理请求
 		c.Next()
 
-		r.Resp = customWriter.body.String()
 		r.Out = time.Now()
+		if cfg.LogBody {
+			r.Resp = customWriter.body.String()
+		} else {
+			r.Resp = "[REDACTED]"
+		}
+
 		slog.Debug("LPM", slog.Any("info", r))
-		slog.Info("LPM", slog.String("catch", r.Method+" "+r.URL))
+		slog.Info("LPM", slog.String("req-id", r.ReqID), slog.String("catch", r.Method+" "+r.URL))
 	}
 }


### PR DESCRIPTION
## 修复问题

解决 Issues #50, #42

## 问题详情

### #50 处理器 panic 未被捕获

`gin/ginapiserver.go` 使用 `gin.New()` 创建引擎，不包含任何默认中间件：
```go
routerGin := gin.New()  // 无 Recovery 中间件
```

当处理器（handler）发生 panic 时，整个服务器进程会崩溃，导致服务不可用。

修复：在所有用户中间件之前添加 `gin.Recovery()`：
```go
routerGin := gin.New()
routerGin.Use(gin.Recovery())  // 确保任何 handler panic 被捕获
```

### #42 日志中间件记录敏感信息

`gin/middleware/log_plus.go` 的 `LogPlusMiddleware()` 直接记录完整的请求/响应 body 和所有 header，可能暴露：
- Authorization token
- Cookie（含 session）
- API key
- 密码、PII 等敏感数据

修复方案：
1. **默认不记录 body**，防止意外泄露数据
2. **自动脱敏敏感 header**（Authorization、Cookie、X-API-Key 等）
3. 新增 `LogPlusMiddlewareWithConfig()` 函数，允许按需开启 body 日志
4. 新增 `LogPlusConfig` 配置结构体

```go
// 安全默认配置：不记录 body，脱敏敏感 header
LogPlusMiddleware()

// 调试时可开启完整日志（谨慎使用）
LogPlusMiddlewareWithConfig(LogPlusConfig{LogBody: true, LogHeaders: true})
```

## 影响范围

- **稳定性提升**：服务器不会因 handler panic 而崩溃
- **安全性提升**：敏感数据不会泄露到日志中
- **向后兼容**：`LogPlusMiddleware()` 接口不变，但默认行为更安全

## 注意事项

`LogPlusMiddleware()` 的默认行为已改变：body 不再被记录（改为 `[REDACTED]`）。
如需记录 body，请改用 `LogPlusMiddlewareWithConfig(LogPlusConfig{LogBody: true})`。

Closes #50
Closes #42
