### PR TITLE
fix: 修复 RabbitMQ 配置验证、告警错误处理、魔数文档和状态码日志

### DIFF
--- a/gin/json_codec.go
+++ b/gin/json_codec.go
@@ -3,6 +3,7 @@ package gin
 import (
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 )
 
@@ -24,6 +25,7 @@ func (j JSONEncoder) Mime() string {
 
 func (d JSONEncoder) HttpResponseError(w http.ResponseWriter, code int, err error) {
 	if code < 200 || code > 599 {
+		slog.Warn("HttpResponseError: invalid status code, defaulting to 500", slog.Int("code", code))
 		code = http.StatusInternalServerError
 	}
 

--- a/gin/text_codec.go
+++ b/gin/text_codec.go
@@ -2,6 +2,7 @@ package gin
 
 import (
 	"io"
+	"log/slog"
 	"net/http"
 	"reflect"
 )
@@ -38,6 +39,7 @@ func NewTextEncoder(w io.Writer) TextEncoder {
 
 func (d TextEncoder) HttpResponseError(w http.ResponseWriter, code int, err error) {
 	if code < 200 || code > 599 {
+		slog.Warn("HttpResponseError: invalid status code, defaulting to 500", slog.Int("code", code))
 		code = http.StatusInternalServerError
 	}
 

--- a/rabbitmq/consumer.go
+++ b/rabbitmq/consumer.go
@@ -30,7 +30,7 @@ func (c *consumer) Validate() error {
 		return errors.New("channel config is nil")
 	}
 	if c.channel.config.ChannelNum == 0 {
-		c.channel.config.ChannelNum = 0
+		c.channel.config.ChannelNum = 1
 	}
 	if c.channel.config.QueueName == "" {
 		return errors.New("queue is nil")
@@ -70,6 +70,7 @@ func (c *consumer) GetConn() error {
 		}
 	}
 	var reconnectCount = 0
+	// maxReconnectCount limits reconnection attempts before triggering an alarm notification
 	var maxReconnectCount = 3
 	var alarmFlag bool
 	for {
@@ -79,12 +80,16 @@ func (c *consumer) GetConn() error {
 				if !alarmFlag {
 					slog.Error("RabbitMQ.Consumer", slog.String("info", err.Error()))
 					if c.alarm != nil {
-						_ = c.alarm.SetMsg(map[string]string{
+						if err := c.alarm.SetMsg(map[string]string{
 							"Title":   "RabbitMQ 连接失败超出阈值",
 							"Address": c.channel.config.Address,
 							"Queue":   c.channel.config.QueueName,
-						})
-						_ = c.alarm.Do()
+						}); err != nil {
+							slog.Error("RabbitMQ.Consumer alarm.SetMsg", slog.String("error", err.Error()))
+						}
+						if err := c.alarm.Do(); err != nil {
+							slog.Error("RabbitMQ.Consumer alarm.Do", slog.String("error", err.Error()))
+						}
 					}
 					alarmFlag = true
 				}

--- a/rabbitmq/producer.go
+++ b/rabbitmq/producer.go
@@ -34,6 +34,7 @@ func (p *producer) Validate() error {
 		return errors.New("channel is nil,please init channel")
 	}
 	if p.sendBodyLength == 0 {
+		// 4096 is the default message queue buffer size (number of messages buffered in memory)
 		p.sendBodyLength = 4096
 	}
 	p.sendBody = make(chan []byte, p.sendBodyLength)
@@ -53,6 +54,7 @@ func (p *producer) Run() {
 
 func (p *producer) Send(body []byte, channel *channel) {
 	retryCount := 0
+	// maxReconnectCount limits reconnection attempts before triggering an alarm notification
 	maxReconnectCount := 3
 	for {
 		err := channel.Chan[0].PublishWithContext(
@@ -77,12 +79,16 @@ func (p *producer) Send(body []byte, channel *channel) {
 			if retryCount >= maxReconnectCount {
 				slog.Error("RabbitMQ.Producer", slog.String("info", err.Error()))
 				if p.alarm != nil {
-					_ = p.alarm.SetMsg(map[string]string{
+					if err := p.alarm.SetMsg(map[string]string{
 						"Title":   "RabbitMQ-Producer 连接失败超出阈值",
 						"Address": p.channel.config.Address,
 						"Queue":   p.channel.config.QueueName,
-					})
-					_ = p.alarm.Do()
+					}); err != nil {
+						slog.Error("RabbitMQ.Producer alarm.SetMsg", slog.String("error", err.Error()))
+					}
+					if err := p.alarm.Do(); err != nil {
+						slog.Error("RabbitMQ.Producer alarm.Do", slog.String("error", err.Error()))
+					}
 				}
 				return
 			}


### PR DESCRIPTION
## 修复问题

解决 Issues #41, #51, #53, #54

## 问题详情

### #41 RabbitMQ 配置验证 bug
`consumer.go` 中的 `Validate()` 方法存在无效赋值：
```go
if c.channel.config.ChannelNum == 0 {
    c.channel.config.ChannelNum = 0  // 无效！设置 0 到 0
}
```
修复：将默认值改为 1，确保 channel 数量不为零。

### #51 告警通知错误被忽略
`consumer.go` 和 `producer.go` 中的告警错误被静默丢弃：
```go
_ = c.alarm.SetMsg(...)  // 错误被忽略
_ = c.alarm.Do()         // 错误被忽略
```
修复：使用 `slog.Error` 记录错误，确保问题可见。

### #53 魔数缺少注释
`sendBodyLength: 4096` 等魔数缺少解释。
修复：添加注释说明这些值的含义和选择原因。

### #54 HTTP 状态码调整缺少日志
当传入无效状态码时被静默调整为 500，没有任何日志输出。
修复：添加 `slog.Warn` 日志记录，方便调试排查。

## 影响范围
- 提升 RabbitMQ 连接可靠性
- 改善告警系统的可观测性
- 提高代码可读性
- 便于 HTTP 问题排查

Closes #41
Closes #51
Closes #53
Closes #54
